### PR TITLE
fix: make batch images a list

### DIFF
--- a/scripts/controlnet.py
+++ b/scripts/controlnet.py
@@ -907,7 +907,7 @@ class Script(scripts.Script):
     def postprocess_batch(self, p, *args, **kwargs):
         images = kwargs.get('images', [])
         for post_processor in self.post_processors:
-            for i in range(images.shape[0]):
+            for i in range(len(images)):
                 images[i] = post_processor(images[i])
         return
 


### PR DESCRIPTION
In [sd-webui-comfyui](https://github.com/ModelSurge/sd-webui-comfyui) we need `images` to be a list, so that each image in the list can have an arbitrary size, and so that the list size can change arbitrarily.

Note that `len(tensor)` is defined and is the same as `tensor.shape[0]`. It has been a thing for a long time:
https://github.com/pytorch/pytorch/blame/e3539a0e5497677a0f7ef29dc8278d249bbccb43/torch/_tensor.py#L907

See https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/11933 for details.